### PR TITLE
Change way of getting boost on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ matrix:
     - compiler: gcc
       addons:
         apt:
+          update: true
           sources:
             - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:mhier/libboost-latest'
           packages:
             - g++-7
+            - boost1.67
       env:
       - C_COMPILER=gcc-7
       - CXX_COMPILER=g++-7
@@ -27,6 +30,7 @@ matrix:
     #   - CXX_COMPILER=clang++-3.8
 
 # Build steps
+
 install:
   - mkdir boost-dl; cd boost-dl
   - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
             - sourceline: 'ppa:mhier/libboost-latest'
           packages:
             - g++-7
-            - boost1.67
+            - boost1.68
       env:
       - C_COMPILER=gcc-7
       - CXX_COMPILER=g++-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
 # Build steps
 script:
   - mkdir boost-dl; cd boost-dl
-  - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
+  - travis-retry wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
   - tar --bzip2 -xf ./boost_1_65_1.tar.bz2
   - sudo mv ./boost_1_65_1/boost /usr/include
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,17 @@ matrix:
     #   - CXX_COMPILER=clang++-3.8
 
 # Build steps
-script:
+install:
   - mkdir boost-dl; cd boost-dl
-  - travis-retry wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
+  - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
   - tar --bzip2 -xf ./boost_1_65_1.tar.bz2
   - sudo mv ./boost_1_65_1/boost /usr/include
   - cd ..
   - mkdir sfml-dl; cd sfml-dl
   - wget https://www.sfml-dev.org/files/SFML-2.5.0-linux-gcc-64-bit.tar.gz
   - tar xzf SFML-2.5.0-linux-gcc-64-bit.tar.gz
+
+script:
   - cd ../
   - export SFML=`pwd`/sfml-dl/SFML-2.5.0
   - echo "sflm $SFML"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ matrix:
 # Build steps
 
 install:
-  - mkdir boost-dl; cd boost-dl
-  - wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
-  - tar --bzip2 -xf ./boost_1_65_1.tar.bz2
-  - sudo mv ./boost_1_65_1/boost /usr/include
-  - cd ..
+        #- mkdir boost-dl; cd boost-dl
+        #- wget https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
+        #- tar --bzip2 -xf ./boost_1_65_1.tar.bz2
+        #- sudo mv ./boost_1_65_1/boost /usr/include
+        #- cd ..
   - mkdir sfml-dl; cd sfml-dl
   - wget https://www.sfml-dev.org/files/SFML-2.5.0-linux-gcc-64-bit.tar.gz
   - tar xzf SFML-2.5.0-linux-gcc-64-bit.tar.gz


### PR DESCRIPTION
Instead of downloading from boost web page and build add repository with precompiled boost available and install from package manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nadzwyczajnagruparobocza/bomberman/95)
<!-- Reviewable:end -->
